### PR TITLE
Fix updateMeta and sendMessage methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "tcdent/php-restclient": "^0.1.5"
+        "tcdent/php-restclient": "^0.1.7"
     },
     "autoload": {
         "files": ["crisp.php"]

--- a/ressources/PluginSubscriptions.php
+++ b/ressources/PluginSubscriptions.php
@@ -51,8 +51,7 @@ class CrispPluginSubscriptions
   }
 
   public function saveSubscriptionSettings($websiteId, $pluginId, $settings) {
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "/plugins/subscription/$websiteId/$pluginId/settings",
       json_encode($settings)
     );

--- a/ressources/UserAvailability.php
+++ b/ressources/UserAvailability.php
@@ -19,8 +19,7 @@ class CrispUserAvailability
   }
 
   public function update($availability) {
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "user/availability",
       json_encode($availability)
     );

--- a/ressources/UserNotification.php
+++ b/ressources/UserNotification.php
@@ -19,7 +19,8 @@ class CrispUserNotification
   }
 
   public function update($params) {
-    $result = $this->crisp->_rest->execute("user/account/account", "PATCH",
+    $result = $this->crisp->_rest->patch(
+      "user/account/account",
       json_encode($params)
     );
   }

--- a/ressources/UserProfile.php
+++ b/ressources/UserProfile.php
@@ -19,7 +19,8 @@ class CrispUserProfile
   }
 
   public function update($params) {
-    $result = $this->crisp->_rest->execute("user/account/profile", "PATCH",
+    $result = $this->crisp->_rest->patch(
+      "user/account/profile",
       json_encode($params)
     );
   }

--- a/ressources/WebsiteConversations.php
+++ b/ressources/WebsiteConversations.php
@@ -72,8 +72,7 @@ class CrispWebsiteConversations
   public function acknowledgeMessages(
     $websiteId, $sessionId, $read) {
 
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/conversation/$sessionId/read",
       json_encode($read)
     );
@@ -102,8 +101,7 @@ class CrispWebsiteConversations
   public function setState(
     $websiteId, $sessionId, $state) {
 
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/conversation/$sessionId/state",
       json_encode(array("state" => $state))
     );
@@ -113,8 +111,7 @@ class CrispWebsiteConversations
   public function setBlock(
     $websiteId, $sessionId, $blocked = true) {
 
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/conversation/$sessionId/block",
       json_encode($blocked)
     );

--- a/ressources/WebsiteConversations.php
+++ b/ressources/WebsiteConversations.php
@@ -64,7 +64,7 @@ class CrispWebsiteConversations
 
     $result = $this->crisp->_rest->post(
       "website/$websiteId/conversation/$sessionId/message",
-      $message
+      json_encode($message)
     );
     return $result->decode_response()["data"];
   }

--- a/ressources/WebsiteConversations.php
+++ b/ressources/WebsiteConversations.php
@@ -92,8 +92,7 @@ class CrispWebsiteConversations
   public function updateMeta(
     $websiteId, $sessionId, $metas) {
 
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/conversation/$sessionId/meta",
       json_encode($metas)
     );

--- a/ressources/WebsiteOperators.php
+++ b/ressources/WebsiteOperators.php
@@ -29,9 +29,8 @@ class CrispWebsiteOperators
   }
 
   public function updateOne($websiteId, $operatorId, $params) {
-    $result = $this->crisp->_rest->execute(
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/operator/$operatorId",
-      "PATCH",
       $params
     );
     return $result->decode_response()["data"];

--- a/ressources/WebsitePeople.php
+++ b/ressources/WebsitePeople.php
@@ -81,8 +81,7 @@ class CrispWebsitePeople
   }
 
   public function updatePeopleProfile($websiteId, $peopleId, $data) {
-    $result = $this->crisp->_rest->execute(
-      "PATCH",
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/people/profile/$peopleId",
       json_encode($data)
     );

--- a/ressources/WebsiteSettings.php
+++ b/ressources/WebsiteSettings.php
@@ -19,9 +19,8 @@ class CrispWebsiteSettings
   }
 
   public function update($websiteId, $params) {
-    $result = $this->crisp->_rest->execute(
+    $result = $this->crisp->_rest->patch(
       "website/$websiteId/settings",
-      "PATCH",
       $params
     );
     return $result->decode_response()["data"];


### PR DESCRIPTION
`updateMeta` called the ReST client `execute` method with wrong order of arguments which was fixed by replacing it with `patch` method.
`sendMessage` did not encode the `$message` parameter which caused inconsistency in usage of the client. It was fixed as well. 