### PR TITLE
Add conversation routing related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ echo "Hello $firstName";
   * **Initiate a Conversation**: `CrispClient->websiteConversations->initiateOne(websiteId, sessionId)`
   * **Send a Conversation**: `CrispClient->websiteConversations->sendMessage(websiteId, sessionId, message)`
   * **Set Conversation State:**: `CrispClient->websiteConversations->setState(websiteId, sessionId, state)`
+  * **Get Conversation Routing**: `CrispClient->websiteConversations->getRouting(websiteId, sessionId)`
+  * **Assign Conversation Routing**:`CrispClient->websiteConversations->assignRouting(websiteId, sessionId, params)`
   * **Block Conversation:**: `CrispClient->websiteConversations->setBlock(websiteId, sessionId, blocked)`
   * **Delete Conversation:**:`CrispClient->websiteConversations->deleteOne(websiteId, sessionId)`
   * **Acknowledge Messages:**: `CrispClient->acknowledgeMessages(websiteId, sessionId, fingerprints)`

--- a/resources/WebsiteConversations.php
+++ b/resources/WebsiteConversations.php
@@ -79,6 +79,25 @@ class CrispWebsiteConversations
     return $result->decode_response()["data"];
   }
 
+  public function getRouting(
+    $websiteId, $sessionId) {
+
+    $result = $this->crisp->_rest->get(
+      "website/$websiteId/conversation/$sessionId/routing"
+    );
+    return $result->decode_response()["data"];
+  }
+
+  public function assignRouting(
+    $websiteId, $sessionId, $routing) {
+
+    $result = $this->crisp->_rest->patch(
+      "website/$websiteId/conversation/$sessionId/routing",
+      json_encode($routing)
+    );
+    return $result->decode_response()["data"];
+  }
+
   public function getMeta(
     $websiteId, $sessionId) {
 


### PR DESCRIPTION
This PR adds methods related to the conversation routing that can be used like in following examples:

```php
require __DIR__ . '/vendor/autoload.php';
$CrispClient = new Crisp();

$CrispClient->authenticate(identifier, key);

$routing = $CrispClient->websiteConversations->getRouting($websiteId, $sessionId);
```

```php
require __DIR__ . '/vendor/autoload.php';
$CrispClient = new Crisp();

$CrispClient->authenticate(identifier, key);

$params = [
  'assigned' => [
    'user_id' => $userId,
  ]
];
$routing = $CrispClient->websiteConversations->assignRouting($websiteId, $sessionId, $params);
```