### PR TITLE
Add properties in class

### DIFF
--- a/src/CrispClient.php
+++ b/src/CrispClient.php
@@ -46,42 +46,52 @@ class CrispClient
      * @var Buckets
      */
     public $buckets;
+
     /**
      * @var UserProfile
      */
     public $userProfile;
+
     /**
      * @var Website
      */
     public $website;
+
     /**
      * @var WebsiteVerify
      */
     public $websiteVerify;
+
     /**
      * @var WebsiteSettings
      */
     public $websiteSettings;
+
     /**
      * @var WebsiteConversations
      */
     public $websiteConversations;
+
     /**
      * @var WebsitePeople
      */
     public $websitePeople;
+
     /**
      * @var WebsiteAvailability
      */
     public $websiteAvailability;
+
     /**
      * @var WebsiteOperators
      */
     public $websiteOperators;
+
     /**
      * @var WebsiteVisitors
      */
     public $websiteVisitors;
+
     /**
      * @var PluginSubscriptions
      */

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -11,6 +11,9 @@ abstract class Resource
     /** @var CrispClient */
     protected $crisp;
 
+    /**
+     * @param CrispClient $parent
+     */
     public function __construct($parent)
     {
         $this->crisp = $parent;


### PR DESCRIPTION
Hi @eliottvincent

When using phpstan/psalm, there is error when we access to properties which are not clearly defined in the class.
Also, this avoid deprecation with php 8.1 and an error with php 9.