### PR TITLE
Fix arbitrary expressions in empty are only allowed in php 5.5 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "php": ">=5.4",
+        "php": ">=5.5",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0"
     },


### PR DESCRIPTION
Currently on a crisp trial & decided to dive into the internals of this package, I noticed that my IDE warn me of the following error in WebsitePeople.php line 43.

`arbitrary expressions in empty are only allowed in php 5.5`

However, rather than trying to make it compatible with PHP 5.4 (See: https://www.drupal.org/project/scheduler/issues/2432473)

I decided to just bump the minimum from PHP 5.4 to PHP 5.5

Reason being, according to the official PHP Packagist https://packagist.org/packages/crispchat/php-crisp-api/php-stats

As of 2023 March 21st, 0% of the people installing this PHP package are running on PHP 5.4, 5.5, 5.6

I decided to be conservative and just bump it to PHP 5.5 minimum but if you want to bump the minimum to even higher, that would be great! As a higher minimum PHP version would likely attract more people to contribute PRs

Also to note is that all versions below PHP 8.0 no longer receive security patches

https://www.php.net/supported-versions.php