### PR TITLE
Fix inconsistency in listPeopleEvent method by adding listPeopleEvents & marking listPeopleEvent() deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ All methods that you will most likely need when building a Crisp integration are
       </details>
 
   * **List Events** [`user`, `plugin`]: [Reference](https://docs.crisp.chat/references/rest-api/v1/#list-people-events)
-    * `CrispClient->websitePeople->listPeopleEvent(websiteId, peopleId, pageNumber)`
+    * `CrispClient->websitePeople->listPeopleEvents(websiteId, peopleId, pageNumber)`
     * <details>
       <summary>See Example</summary>
 
@@ -505,7 +505,7 @@ All methods that you will most likely need when building a Crisp integration are
       $peopleId = "c5a2f70c-f605-4648-b47f-8c39d4b03a50";
       $pageNumber = 1;
 
-      CrispClient->websitePeople->listPeopleEvent(websiteId, peopleId, pageNumber);
+      CrispClient->websitePeople->listPeopleEvents(websiteId, peopleId, pageNumber);
       ```
       </details>
 

--- a/src/Resources/WebsitePeople.php
+++ b/src/Resources/WebsitePeople.php
@@ -209,7 +209,7 @@ class WebsitePeople extends Resource
      * @throws ClientExceptionInterface
      * @throws CrispException
      */
-    public function listPeopleEvents($websiteId, $peopleId, $pageNumber)
+    public function listPeopleEvents($websiteId, $peopleId, $pageNumber = 1)
     {
         $result = $this->crisp->get(
             "website/$websiteId/people/events/$peopleId/list/$pageNumber"

--- a/src/Resources/WebsitePeople.php
+++ b/src/Resources/WebsitePeople.php
@@ -209,6 +209,23 @@ class WebsitePeople extends Resource
      * @throws ClientExceptionInterface
      * @throws CrispException
      */
+    public function listPeopleEvents($websiteId, $peopleId, $pageNumber)
+    {
+        $result = $this->crisp->get(
+            "website/$websiteId/people/events/$peopleId/list/$pageNumber"
+        );
+        return $this->formatResponse($result);
+    }
+
+    /**
+     * @param string $websiteId
+     * @param string $peopleId
+     * @param int $pageNumber
+     * @return array
+     * @throws ClientExceptionInterface
+     * @throws CrispException
+     */
+    #[\Deprecated(message: 'use listPeopleEvents() instead')]
     public function listPeopleEvent($websiteId, $peopleId, $pageNumber)
     {
         $result = $this->crisp->get(


### PR DESCRIPTION
Currently the listPeopleEvent method in Crisp is not consistent with the other methods in the WebsitePeople class. Such as:

- listPeopleProfiles
- listPeopleSegments
- listPeopleConversations

That is, the method name should end with a plural s, but it did not.

This PR adds a listPeopleEvents() method that does the exact same thing. Then mark the listPeopleEvent() method as deprecated using PHP 8.4 deprecated attribute.

According to https://youtrack.jetbrains.com/issue/WI-62847/Option-to-allow-attributes-in-PHP-8.0-in-language-level-inspection

> They are not supported in PHP < 8.0, BUT: If every attribute is on a separate line, then PHP 7.0 won't crash, it will simply ignore them.



